### PR TITLE
overflowing_literals false positive

### DIFF
--- a/src/lib/stack/mod.rs
+++ b/src/lib/stack/mod.rs
@@ -55,7 +55,7 @@ impl VM{
 
 
 	fn get_type(&self, instruction:i32)->i32{
-		(instruction & 0xC0000000)>>30//2 msb	
+		(instruction & 0xC0000000_u32 as i32)>>30//2 msb	
 		
 	}
 	fn get_data(&self, instruction:i32)->i32{


### PR DESCRIPTION
In a future version of Rust the `overflowing_literals` lint will become deny by default. See rust-lang/rust#55632. When checking for breakage in crates uploaded to crates.io it was discovered that this crate will no longer compile thanks to this lint. The error produced is [here](https://crater-reports.s3.amazonaws.com/pr-55632/try%23dc13be39fae8d4c607889b27de374b52586485a3/gh/NishanthSpShetty.Stack-VM/log.txt). This PR should fix the false positive.